### PR TITLE
Set-up lintr check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .Rproj.user
 inst/doc
+.Rhistory

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,0 @@
-linters: linters_with_defaults() # see vignette("lintr")
-encoding: "UTF-8"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,6 @@ Imports:
     stats
 Suggests: 
     knitr,
+    lintr,
     rmarkdown
 VignetteBuilder: knitr

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(projectPackage)
+
+test_check("projectPackage")

--- a/tests/testthat/test-lint-free.R
+++ b/tests/testthat/test-lint-free.R
@@ -1,0 +1,5 @@
+if (requireNamespace("lintr", quietly = TRUE)) {
+  test_that("Package is lint-free", {
+    lintr::expect_lint_free()
+  })
+}


### PR DESCRIPTION
- Used `usethis` to setup the test folder
- Added lintr test, will run only if package lintr is available.
- `lintr` is a "suggests" dependency (see DESCRIPTION) 